### PR TITLE
Upgrade to HTMLUnit 2.31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+dependency-reduced-pom.xml
+target
+
 *.class
 
 # Mobile Tools for Java (J2ME)

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <!-- Version number [htmlunit-version]-[this artifact iteration for that version] -->
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>jenkins-test-harness-htmlunit</artifactId>
-  <version>2.30-1-SNAPSHOT</version>
+  <version>2.31-1-SNAPSHOT</version>
 
   <name>HtmlUnit dependency for Jenkins Test Harness</name>
   <description>Encapsulates HtmlUnit dependency, shading conflicting dependencies.</description>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>net.sourceforge.htmlunit</groupId>
       <artifactId>htmlunit</artifactId>
-      <version>2.30</version>
+      <version>2.31</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-io</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-xml</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <!-- Version number [htmlunit-version]-[this artifact iteration for that version] -->
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>jenkins-test-harness-htmlunit</artifactId>
-  <version>2.26-1-SNAPSHOT</version>
+  <version>2.30-1-SNAPSHOT</version>
 
   <name>HtmlUnit dependency for Jenkins Test Harness</name>
   <description>Encapsulates HtmlUnit dependency, shading conflicting dependencies.</description>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>net.sourceforge.htmlunit</groupId>
       <artifactId>htmlunit</artifactId>
-      <version>2.26</version>
+      <version>2.30</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>


### PR DESCRIPTION
Required for jenkinsci/jenkins-test-harness#103

Makes #1 obsolete.