### PR TITLE
maven-shade xalan and xercesImpl, excluding JAXP registration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,8 @@
                 <includes>
                   <include>net.sourceforge.htmlunit:*</include>
                   <include>org.apache.httpcomponents:*</include>
+                  <include>xalan:xalan</include>
+                  <include>xerces:xercesImpl</include>
                 </includes>
               </artifactSet>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
@@ -109,6 +111,24 @@
                   <shadedPattern>hidden.jth.org.apache.http</shadedPattern>
                 </relocation>
               </relocations>
+              <filters>
+                <filter>
+                  <artifact>xalan:xalan</artifact>
+                  <excludes>
+                    <!-- disable Xalan-J JAXP registration -->
+                    <exclude>META-INF/services/javax.xml.*</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>xerces:xercesImpl</artifact>
+                  <excludes>
+                    <!-- disable Xerces JAXP registration -->
+                    <exclude>META-INF/services/javax.xml.*</exclude>
+                    <exclude>META-INF/services/org.w3c.*</exclude>
+                    <exclude>META-INF/services/org.xml.*</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
See jenkinsci/jenkins-test-harness#89. 

Having Xalan-J auto-registering itself as the JAXP provider for `javax.xml.transform.TransformerFactory` is causing issues in `ItemGroupMixIn.createProjectFromXML` (because of a Xalan-J bug). Because we can't completely get rid of it (`htmlunit` actually explicitly depends on some Xalan APIs), @jglick has proposed that we `maven-shade` it in `jenkins-test-harness-htmlunit`, with appropriate filtering to disable its JAXP registration. And that we do the same for Xerces too, for similar reason.  The goal here is to avoid incidentally using a non-standard JAXP stack when running JTH tests.

- JAXP registrations I've disabled in `xalan`:
```
META-INF/services/javax.xml.transform.TransformerFactory: org.apache.xalan.processor.TransformerFactoryImpl
META-INF/services/javax.xml.xpath.XPathFactory: org.apache.xpath.jaxp.XPathFactoryImpl
```
(I've kept `META-INF/services/org.apache.xalan.extensions.bsf.BSFManager` and `META-INF/services/org.apache.xml.dtm.DTMManager`, because they are specific to `xalan`, and should not interfere with the JDK JAXP stack)

- JAXP registrations I've disabled in `xercesImpl`:
```
META-INF/services/javax.xml.datatype.DatatypeFactory: org.apache.xerces.jaxp.datatype.DatatypeFactoryImpl
META-INF/services/javax.xml.parsers.DocumentBuilderFactory: org.apache.xerces.jaxp.DocumentBuilderFactoryImpl
META-INF/services/javax.xml.parsers.SAXParserFactory: org.apache.xerces.jaxp.SAXParserFactoryImpl
META-INF/services/javax.xml.stream.XMLEventFactory: org.apache.xerces.stax.XMLEventFactoryImpl
META-INF/services/javax.xml.validation.SchemaFactory: org.apache.xerces.jaxp.validation.XMLSchemaFactory
META-INF/services/org.w3c.dom.DOMImplementationSourceList: org.apache.xerces.dom.DOMXSImplementationSourceImpl
META-INF/services/org.xml.sax.driver: org.apache.xerces.parsers.SAXParser

```

To validate that this will not completely break `htmlunit` itself (and thus some legitimate unit tests in Jenkins plugins), I have executed the `htmlunit` unit tests suite with OpenJDK 8 and modified versions of the `xalan` and `xercesImpl` jars.

Out of **62998 tests** (in `htmlunit` version 2.31):

- disabling `xalan` JAXP registration breaks 3 tests (3 times the same test actually):
https://github.com/HtmlUnit/htmlunit/blob/HtmlUnit-2.31/src/test/java/com/gargoylesoftware/htmlunit/libraries/Sarissa0993Test.java#L45
```
[ERROR] Sarissa0993Test.sarissa [Chrome](com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test)  Time elapsed: 3.273 s  <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<...stCase Results
++++F[+]++> but was:<...stCase Results
++++F[F]++>
	at com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test.verify(Sarissa0993Test.java:75)
	at com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test.sarissa(Sarissa0993Test.java:62)

[ERROR] Sarissa0993Test.sarissa [FF45](com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test)  Time elapsed: 0.589 s  <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<...stCase Results
++++F[+]++> but was:<...stCase Results
++++F[F]++>
	at com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test.verify(Sarissa0993Test.java:75)
	at com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test.sarissa(Sarissa0993Test.java:62)

[ERROR] Sarissa0993Test.sarissa [FF52](com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test)  Time elapsed: 0.534 s  <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<...stCase Results
++++F[+]++> but was:<...stCase Results
++++F[F]++>
	at com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test.verify(Sarissa0993Test.java:75)
	at com.gargoylesoftware.htmlunit.libraries.Sarissa0993Test.sarissa(Sarissa0993Test.java:62)
```
(so that's one of the `XSLTProcessorTestCase`, but I've not looked into the details)

- also disabling `xerces` JAXP breaks 3 more tests (3 times the same test actually):
https://github.com/HtmlUnit/htmlunit/blob/HtmlUnit-2.31/src/test/java/com/gargoylesoftware/htmlunit/javascript/host/xml/XMLDocument2Test.java#L532
```
[ERROR] XMLDocument2Test.attributeOrder [Chrome](com.gargoylesoftware.htmlunit.javascript.host.xml.XMLDocument2Test)  Time elapsed: 0.339 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[[name: item1, id: 1, id: 2, name: item2, name: item3, id: ]3]> but was:<[[id: 1, name: item1, id: 2, name: item2, id: 3, name: item]3]>
	at com.gargoylesoftware.htmlunit.javascript.host.xml.XMLDocument2Test.attributeOrder(XMLDocument2Test.java:552)

[ERROR] XMLDocument2Test.attributeOrder [FF45](com.gargoylesoftware.htmlunit.javascript.host.xml.XMLDocument2Test)  Time elapsed: 0.308 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[[name: item1, id: 1, id: 2, name: item2, name: item3, id: ]3]> but was:<[[id: 1, name: item1, id: 2, name: item2, id: 3, name: item]3]>
	at com.gargoylesoftware.htmlunit.javascript.host.xml.XMLDocument2Test.attributeOrder(XMLDocument2Test.java:552)

[ERROR] XMLDocument2Test.attributeOrder [FF52](com.gargoylesoftware.htmlunit.javascript.host.xml.XMLDocument2Test)  Time elapsed: 0.292 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[[name: item1, id: 1, id: 2, name: item2, name: item3, id: ]3]> but was:<[[id: 1, name: item1, id: 2, name: item2, id: 3, name: item]3]>
	at com.gargoylesoftware.htmlunit.javascript.host.xml.XMLDocument2Test.attributeOrder(XMLDocument2Test.java:552)
```
(so it looks like whatever implementation is in OpenJDK 8 does not preserve attributes order like `xerces` does)

I have also executed `htmlunit-neko` (2.31) unit tests with my modified `xercesImpl` (because that's a lib which `htmlunit` depends on, and which itself depends on `xercesImpl`), and it all went fine.

In my opinion, these are "good enough" results to not fear regressions in plugins unit tests which rely on `htmlunit`, so I think we should move forward with this idea.