### PR TITLE
Shade commons-lang3 and commons-text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
                   <include>net.sourceforge.htmlunit:*</include>
                   <include>org.apache.httpcomponents:*</include>
                   <include>org.apache.commons:commons-lang3</include>
+                  <include>org.apache.commons:commons-text</include>
                   <include>xalan:xalan</include>
                   <include>xerces:xercesImpl</include>
                 </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
                 <includes>
                   <include>net.sourceforge.htmlunit:*</include>
                   <include>org.apache.httpcomponents:*</include>
+                  <include>org.apache.commons:commons-lang3</include>
                   <include>xalan:xalan</include>
                   <include>xerces:xercesImpl</include>
                 </includes>


### PR DESCRIPTION
Only picks up commons-lang2 now
```
$ mvn dependency:tree | grep commons-lang
[INFO] |  |  +- commons-lang:commons-lang:jar:2.6:compile (optional)
```