### PR TITLE
Enable Release Drafter, abandon coversioning with htmlunit

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+_extends: .github
+tag-template: jenkins-test-harness-htmlunit-$NEXT_MAJOR_VERSION
+version-template: $MAJOR

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,11 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -8,10 +8,9 @@
     <version>1.36</version>
   </parent>
 
-  <!-- Version number [htmlunit-version]-[this artifact iteration for that version] -->
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>jenkins-test-harness-htmlunit</artifactId>
-  <version>2.36.0-2-SNAPSHOT</version>
+  <version>3-SNAPSHOT</version>
 
   <name>HtmlUnit dependency for Jenkins Test Harness</name>
   <description>Encapsulates HtmlUnit dependency, shading conflicting dependencies.</description>


### PR DESCRIPTION
As of #6 + #8 the original version scheme is no longer tenable.