### PR TITLE
make maven-shade-plugin produce a -sources.jar file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,8 @@
                   </excludes>
                 </filter>
               </filters>
+              <createSourcesJar>true</createSourcesJar>
+              <shadeSourcesContent>true</shadeSourcesContent>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
When debugging some test failures related to HtmlUnit (jenkinsci/jenkins#5479), I've found it annoying that HtmlUnit sources were not available in my IDE. To fix that, this PR adds two `maven-shade-plugin` options:
- [createSourcesJar](https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#createSourcesJar): to get a -sources.jar file
- [shadeSourcesContent](https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#shadeSourcesContent): to apply relocations (`org.apache.http.*` => `hidden.jth.org.apache.http.*`) on the Java sources files

<!-- blah -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
