### PR TITLE
Exclude JSR 305

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
       <version>2.52.0</version>
       <exclusions>
         <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>


### PR DESCRIPTION
This is only used by a transitive dependency (`com.shapesecurity:salvation2:3.0.0`) and I doubt it is needed at runtime.