### PR TITLE
Add Java 11 and 17 to build/test matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,11 @@
-node('maven') {
-    checkout scm
-    sh 'mvn -B -ntp -Dset.changelist clean install'
-    infra.prepareToPublishIncrementals()
-}
-infra.maybePublishIncrementals()
+/*
+ * While this is not a plugin, it is much simpler to reuse the pipeline code for CI. This allows for
+ * easy Linux/Windows testing and produces incrementals. The only feature that relates to plugins is
+ * allowing one to test against multiple Jenkins versions.
+ */
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+  [ platform: 'linux', jdk: '17' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/test/java/jenkins/Junit4TestsRanTest.java
+++ b/src/test/java/jenkins/Junit4TestsRanTest.java
@@ -1,0 +1,14 @@
+package jenkins;
+
+import org.junit.Test;
+
+public class Junit4TestsRanTest {
+
+    @Test
+    public void anything() {
+        /*
+         * Intentionally blank. We just want a test that runs with JUnit so that buildPlugin() works
+         * in the Jenkinsfile.
+         */
+    }
+}


### PR DESCRIPTION
Update the build/test matrix to include recent versions of Java, as is being done in other core components.