### PR TITLE
Remove redundant `project.build.sourceEncoding` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
   </properties>
 


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.