### PR TITLE
Clean up shading configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,20 @@
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
         </exclusion>
+        <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Fix an inconsistencies I noticed when reading this code recently: We were excluding `commons-codec` (presumably because it was provided by Jenkins core) but not `commons-io` and `commons-logging` (which are also provided by Jenkins core). This inconsistency led to the consumer (`jenkins-test-harness`) excluding `commons-io` at the consumption site. If we are to exclude one we should exclude all three. This also reduces the chances of Enforcer conflicts. I tested this by pulling in the new dependency in `jenkins-test-harness` and then running a build on a plugin.