### PR TITLE
Shade any dependencies not provided by Jenkins core or test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencies>
@@ -43,6 +44,7 @@
       <artifactId>htmlunit</artifactId>
       <version>3.3.0</version>
       <exclusions>
+        <!-- Not needed at runtime -->
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
@@ -52,16 +54,15 @@
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>
-        <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
         </exclusion>
-        <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <!-- Provided by Jenkins test harness -->
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-client</artifactId>
@@ -122,18 +123,43 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <artifactSet>
-                <includes>
-                  <include>org.apache.httpcomponents:*</include>
-                  <include>org.apache.commons:commons-lang3</include>
-                  <include>org.apache.commons:commons-text</include>
-                </includes>
-              </artifactSet>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+              <!--
+                This list should contain all packages in the transitive closure of this module except for those provided
+                by Jenkins core or test harness (and therefore excluded above) as well as HtmlUnit itself.
+              -->
               <relocations>
+                <relocation>
+                  <pattern>com.shapesecurity</pattern>
+                  <shadedPattern>hidden.jth.com.shapesecurity</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>mozilla</pattern>
+                  <shadedPattern>hidden.jth.mozilla</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>netscape</pattern>
+                  <shadedPattern>hidden.jth.netscape</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>hidden.jth.org.apache.http</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.lang3</pattern>
+                  <shadedPattern>hidden.jth.org.apache.commons.lang3</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons.text</pattern>
+                  <shadedPattern>hidden.jth.org.apache.commons.text</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.brotli</pattern>
+                  <shadedPattern>hidden.jth.org.brotli</shadedPattern>
                 </relocation>
               </relocations>
               <createSourcesJar>true</createSourcesJar>


### PR DESCRIPTION
When adopted by `jenkins-test-harness`, will fix https://github.com/jenkinsci/jenkins-test-harness/issues/550.

### Testing done

Tested by verifying that Commons Lang 3 was leaking to `custom-folder-icon` before this PR and stopped leaking after this PR, as evidence by a compilation failure (fixed by https://github.com/jenkinsci/custom-folder-icon-plugin/pull/201).

Also tested that plugins that depend on Commons Lang 3 API plugin were now no longer racing with this leaked dependency to see which came first on the classpath.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
