### PR TITLE
Remove unused release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,0 @@
-_extends: .github


### PR DESCRIPTION
## Remove unused release drafter configuration

Release drafter 7 no longer supports the `_extends: .github` syntax, but since this repository does not use the release drafter GitHub action, there is no need to retain the release drafter configuration file.

### Testing done

None.  Rely on GitHub actions to confirm the configuration is not used.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

